### PR TITLE
fix: skip kapeta files w/o kind or name [CORE-2577]

### DIFF
--- a/src/ClusterConfiguration.ts
+++ b/src/ClusterConfiguration.ts
@@ -285,7 +285,6 @@ export class ClusterConfiguration {
 
     getDefinitionErrors() {
         const { errors } = this.getDefinitionFiles();
-        console.log({ errors });
         return errors;
     }
 

--- a/src/ClusterConfiguration.ts
+++ b/src/ClusterConfiguration.ts
@@ -199,7 +199,7 @@ export class ClusterConfiguration {
                 if (!FS.existsSync(obj.ymlPath)) {
                     console.warn(`Invalid definition file ${obj.ymlPath}`);
                     this._errors.push({
-                        message: `Invalid definition file ${obj.ymlPath}`,
+                        message: `Invalid definition file`,
                         definition: {
                             ymlPath: obj.ymlPath,
                             path: obj.path,
@@ -243,8 +243,8 @@ export class ClusterConfiguration {
             const data = document.definition;
             if (!data || !data.kind || !data.metadata || !data.metadata.name) {
                 // TODO: add a real validation framework
-                return `YAML document #${documentIndex + 1} in ${
-                    document.ymlPath
+                return `YAML document #${
+                    documentIndex + 1
                 } was skipped: Invalid data, missing one or more required fields.`;
             }
 

--- a/src/ClusterConfiguration.ts
+++ b/src/ClusterConfiguration.ts
@@ -71,6 +71,10 @@ export interface ClusterConfig {
 
 export class ClusterConfiguration {
     private _clusterConfig?: ClusterConfig;
+    private _errors: {
+        message: string;
+        definition: Partial<DefinitionInfo>;
+    }[] = [];
 
     getClusterServicePort() {
         if (process?.env?.KAPETA_LOCAL_CLUSTER_PORT) {
@@ -167,11 +171,11 @@ export class ClusterConfiguration {
         return this.getDefinitions(resolvedFilters);
     }
 
-    private getDefinitionFiles() {
+    private processDefinitionFiles() {
         const out = {
             valid: [] as DefinitionInfo[],
             errors: [] as {
-                error: string;
+                message: string;
                 definition: Partial<DefinitionInfo>;
             }[],
         };
@@ -245,7 +249,7 @@ export class ClusterConfiguration {
                 const error = validate(definition, i);
                 if (error) {
                     out.errors.push({
-                        error,
+                        message: error,
                         definition,
                     });
                     return;
@@ -262,7 +266,8 @@ export class ClusterConfiguration {
      */
     getDefinitions(kindFilter?: string | string[]) {
         let resolvedFilters: string[] = [];
-        const { valid } = this.getDefinitionFiles();
+        const { valid, errors } = this.processDefinitionFiles();
+        this._errors = errors;
 
         if (kindFilter) {
             if (Array.isArray(kindFilter)) {
@@ -284,8 +289,7 @@ export class ClusterConfiguration {
     }
 
     getDefinitionErrors() {
-        const { errors } = this.getDefinitionFiles();
-        return errors;
+        return this._errors;
     }
 
     getClusterConfigFile() {


### PR DESCRIPTION
Adds validation of `kind` and `metadata.name` fields in all `kapeta.yml` files.
Any yaml documents that don't have the required fields will be skipped, and added to an errors property. The errors can be read by the cluster-service and forwarded to the UI.
